### PR TITLE
fix: secure Forgewright MCP runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Forgewright is designed to run locally alongside your preferred IDE and developm
 
 Please ensure the following dependencies are installed and available in your system path:
 
-- **Node.js**: v18.x or higher (required for GitNexus and MCP servers).
+- **Node.js**: v20.x or higher for MCP setup; the standalone CLI remains compatible with v18+.
 - **Git**: v2.30+ (required for repository management and history tracking).
 - **Python**: v3.8+ (required for the FluxMem SQLite GraphRAG memory layer).
 - **Supported IDE**: Cursor, Claude Desktop, or Codex CLI.
@@ -416,7 +416,7 @@ forge token report --period week
 
 - Restart your IDE completely. Ensure no background zombie node processes are locking the socket.
 - Run `bash scripts/forgewright-mcp-setup.sh --force` to regenerate configuration files.
-- Verify Node v18+ is installed via `node -v` and accessible in your default path.
+- Verify Node v20+ is installed via `node -v` and accessible in your default path.
 
 ### The GitNexus index is stale / Impact analysis fails
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -113,7 +113,7 @@ flowchart LR
         L2A["🔍 Thêm gì"]
         L2B["• Hỏi 'thay đổi này ảnh hưởng gì?' → trả lời ngay"]
         L2C["• Phân tích blast radius tự động"]
-        L2D["• Cần: Node.js 18+"]
+        L2D["• Cần: Node.js 20+ cho MCP"]
     end
 
     subgraph L3["⚡⚡⚡ Level 3 — Memory"]
@@ -996,7 +996,7 @@ git submodule update --init --recursive
 
 ### Cách 2: Nâng cấp lên Level 2 (Smart)
 
-Cần: **Node.js 18+**
+Cần: **Node.js 20+ cho MCP** (CLI độc lập vẫn hỗ trợ Node.js 18+)
 
 ```bash
 # Kiểm tra
@@ -1299,7 +1299,7 @@ npx tsx forgewright/scripts/generate-sequence.ts \
 | Vấn đề | Cách xử lý |
 |---------|------------|
 | `gitnexus: command not found` | Chạy `npm install -g gitnexus && gitnexus setup` |
-| `npm install` bị lỗi trong submodule | Kiểm tra `node --version` (cần 18+) |
+| `npm install` bị lỗi trong submodule | Kiểm tra `node --version` (MCP cần 20+) |
 | Không thấy MCP tools | Khởi động lại Cursor/VS Code sau khi đổi config |
 | Index cũ | Chạy `gitnexus analyze "$(pwd)"` để cập nhật |
 | Submodule chưa khởi tạo | `git submodule update --init --recursive` |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -52,14 +52,14 @@ Expected output:
 
 | Tool | Required | Version | Install |
 |------|----------|---------|---------|
-| Node.js | Yes | 18+ | [nodejs.org](https://nodejs.org) |
+| Node.js | Yes | 20+ | [nodejs.org](https://nodejs.org) |
 | npm | Yes | 8+ | Comes with Node.js |
 | git | Recommended | Any | `brew install git` |
 
 ### Verify Prerequisites
 
 ```bash
-node --version    # Should show v18+
+node --version    # Should show v20+
 npm --version     # Should show 8+
 git --version     # Should show 2.x+
 ```

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -8,8 +8,8 @@
       "name": "forgewright-mcp-global",
       "version": "1.0.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.1",
-        "js-yaml": "^4.1.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "js-yaml": "4.3.0",
         "jsonc-parser": "^3.3.1",
         "zod": "^3.25.76"
       },
@@ -33,7 +33,7 @@
         "vitest": "^1.2.2"
       },
       "engines": {
-        "node": ">=18.19.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1451,12 +1451,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1818,12 +1818,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -4520,9 +4520,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "build/index.js",
   "engines": {
-    "node": ">=18.19.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "build": "tsc",
@@ -19,8 +19,8 @@
     "test:coverage": "vitest run --coverage --reporter=basic"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.1",
-    "js-yaml": "^4.1.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
+    "js-yaml": "4.3.0",
     "jsonc-parser": "^3.3.1",
     "zod": "^3.25.76"
   },
@@ -44,6 +44,8 @@
     "vitest": "^1.2.2"
   },
   "overrides": {
+    "@hono/node-server": "2.0.12",
+    "fast-uri": "3.1.4",
     "esbuild": "^0.25.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,9 @@
       "name": "forgewright-mcp-global",
       "version": "1.0.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.1",
-        "js-yaml": "^4.1.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "js-yaml": "4.3.0",
+        "jsonc-parser": "^3.3.1",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -50,6 +51,9 @@
         "tsx": "^4.22.4",
         "typescript": "^5.3.3",
         "vitest": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "mcp/node_modules/@types/node": {
@@ -60,6 +64,28 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "mcp/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "mcp/node_modules/undici-types": {
@@ -1414,7 +1440,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1432,7 +1457,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1450,7 +1474,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1468,7 +1491,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1486,7 +1508,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1504,7 +1525,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1522,7 +1542,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1540,7 +1559,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1558,7 +1576,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1576,7 +1593,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1594,7 +1610,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1612,7 +1627,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1630,7 +1644,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1648,7 +1661,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1666,7 +1678,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1684,7 +1695,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1702,7 +1712,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1720,7 +1729,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1738,7 +1746,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1756,7 +1763,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1774,7 +1780,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1792,7 +1797,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1810,7 +1814,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1828,7 +1831,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1846,7 +1848,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1864,7 +1865,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1992,12 +1992,12 @@
       "link": true
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2136,12 +2136,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -4408,9 +4408,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6062,9 +6062,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7227,18 +7227,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
@@ -7276,6 +7264,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7352,6 +7341,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
+  "overrides": {
+    "@hono/node-server": "2.0.12",
+    "fast-uri": "3.1.4"
+  },
   "lint-staged": {
     "mcp/src/**/*.ts": [
       "npx --prefix mcp eslint --fix --cache --cache-location mcp/node_modules/.cache/eslint",

--- a/scripts/bootstrap/forgewright-setup.sh
+++ b/scripts/bootstrap/forgewright-setup.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 VERSION="1.0.0"
 GITHUB_REPO="https://github.com/buiphucminhtam/forgewright.git"
 FORGEWRIGHT_DEFAULT="${HOME}/Documents/GitHub/forgewright"
-MIN_NODE_VERSION="18.19.0"
+MIN_NODE_VERSION="20.0.0"
 
 # Colors
 RED='\033[0;31m'
@@ -259,7 +259,7 @@ node_version_is_supported() {
     patch="${patch%%[^0-9]*}"
     [[ "$major" =~ ^[0-9]+$ ]] && [[ "$minor" =~ ^[0-9]+$ ]] && \
         [[ "$patch" =~ ^[0-9]+$ ]] || return 1
-    ((major > 18 || (major == 18 && (minor > 19 || (minor == 19 && patch >= 0)))))
+    ((major >= 20))
 }
 
 check_prerequisites() {

--- a/scripts/lite/stop-gate.sh
+++ b/scripts/lite/stop-gate.sh
@@ -7,6 +7,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLATFORM=""
 MAX_PAYLOAD_BYTES=1048576
+MAX_VERIFY_STDERR_BYTES=65536
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -26,9 +27,14 @@ done
 
 PLATFORM="$(printf '%s' "$PLATFORM" | tr '[:lower:]' '[:upper:]')"
 PAYLOAD_FILE="$(mktemp "${TMPDIR:-/tmp}/forgewright-stop.XXXXXX")" || exit 1
-chmod 600 "$PAYLOAD_FILE" 2>/dev/null || true
-cleanup() {
+VERIFY_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/forgewright-verify-stderr.XXXXXX")" || {
   rm -f "$PAYLOAD_FILE"
+  exit 1
+}
+chmod 600 "$PAYLOAD_FILE" 2>/dev/null || true
+chmod 600 "$VERIFY_STDERR_FILE" 2>/dev/null || true
+cleanup() {
+  rm -f "$PAYLOAD_FILE" "$VERIFY_STDERR_FILE"
 }
 trap cleanup EXIT
 trap 'exit 130' HUP INT TERM
@@ -47,12 +53,85 @@ if [[ "$PAYLOAD_SIZE" -gt "$MAX_PAYLOAD_BYTES" ]]; then
 fi
 
 emit_codex_block() {
-  python3 - <<'PYEOF'
+  python3 - "${1:-Forgewright stop validator rejected the response payload.}" <<'PYEOF'
 import json
+import sys
 print(json.dumps({
     "decision": "block",
-    "reason": "Forgewright stop validator rejected the response payload.",
+    "reason": sys.argv[1][:512],
 }))
+PYEOF
+}
+
+codex_block_reason() {
+  python3 - "$VERIFY_STDERR_FILE" "$VALIDATOR_RC" "$VERIFY_RC" \
+    "$MAX_VERIFY_STDERR_BYTES" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+stderr_path = Path(sys.argv[1])
+rule_rc = int(sys.argv[2])
+verify_rc = int(sys.argv[3])
+stderr_limit = int(sys.argv[4])
+with stderr_path.open("rb") as stderr_stream:
+    text = stderr_stream.read(stderr_limit).decode("utf-8", errors="replace")
+text = re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+safe_reason = ""
+if rule_rc:
+    safe_reason = "Forgewright rule validator rejected the response payload."
+patterns = (
+    (r"MISSING:", "MISSING: no current machine-written evidence was found."),
+    (
+        r"STALE: evidence is ([0-9]+)s old \(limit: ([0-9]+)s\)",
+        lambda match: (
+            f"STALE: evidence is {match.group(1)}s old "
+            f"(limit: {match.group(2)}s)."
+        ),
+    ),
+    (
+        r"MISMATCH: workspace",
+        "MISMATCH: evidence workspace does not match the current workspace.",
+    ),
+    (
+        r"MISMATCH: tree_sha",
+        "MISMATCH: the workspace tree changed after evidence was written.",
+    ),
+    (
+        r"FAILED: evidence exit_code=(-?[0-9]+)",
+        lambda match: f"FAILED: evidence command exited {match.group(1)}.",
+    ),
+    (
+        r"FAILED: exit_code is not an integer",
+        "FAILED: evidence exit code is invalid.",
+    ),
+    (
+        r"SECRETS:",
+        "SECRETS: evidence output contains unredacted secret material.",
+    ),
+    (
+        r"FORGED:",
+        "FORGED: evidence schema or contents failed validation.",
+    ),
+    (
+        r"Code contains stubs:",
+        "STUBS: changed code contains forbidden stubs.",
+    ),
+)
+if not safe_reason:
+    for pattern, replacement in patterns:
+        match = re.search(pattern, text)
+        if match:
+            safe_reason = replacement(match) if callable(replacement) else replacement
+            break
+
+if not safe_reason and verify_rc:
+    safe_reason = "Forgewright evidence validator rejected the response payload."
+elif not safe_reason:
+    safe_reason = "Forgewright stop validator rejected the response payload."
+
+print(safe_reason[:512])
 PYEOF
 }
 
@@ -135,11 +214,26 @@ fi
 
 if [[ "$PLATFORM" == "CODEX" ]]; then
   VERIFY_JSON="$(bash "${SCRIPT_DIR}/verify-gate.sh" --platform CODEX \
-    --payload-file "$PAYLOAD_FILE" 2>/dev/null)"
+    --payload-file "$PAYLOAD_FILE" 2>"$VERIFY_STDERR_FILE")"
   VERIFY_RC=$?
+  VERIFY_BLOCKED=0
+  if python3 - "$VERIFY_JSON" >/dev/null 2>&1 <<'PYEOF'
+import json
+import sys
 
-  if [[ "$VALIDATOR_RC" -ne 0 || "$VERIFY_RC" -ne 0 ]]; then
-    emit_codex_block
+try:
+    payload = json.loads(sys.argv[1])
+except (IndexError, json.JSONDecodeError):
+    raise SystemExit(1)
+raise SystemExit(0 if payload.get("decision") == "block" else 1)
+PYEOF
+  then
+    VERIFY_BLOCKED=1
+  fi
+
+  if [[ "$VALIDATOR_RC" -ne 0 || "$VERIFY_RC" -ne 0 || "$VERIFY_BLOCKED" -eq 1 ]]; then
+    [[ "$VERIFY_BLOCKED" -eq 1 ]] && VERIFY_RC=1
+    emit_codex_block "$(codex_block_reason)"
     exit 0
   fi
 

--- a/scripts/mcp/forgewright-mcp-setup.sh
+++ b/scripts/mcp/forgewright-mcp-setup.sh
@@ -218,14 +218,14 @@ node_version_is_supported() {
     patch="${patch%%[^0-9]*}"
     [[ "$major" =~ ^[0-9]+$ ]] && [[ "$minor" =~ ^[0-9]+$ ]] && \
         [[ "$patch" =~ ^[0-9]+$ ]] || return 1
-    ((major > 18 || (major == 18 && (minor > 19 || (minor == 19 && patch >= 0)))))
+    ((major >= 20))
 }
 
 check_prerequisites() {
     log_step "Checking prerequisites..."
 
     if ! command -v node &> /dev/null; then
-        log_error "Node.js not found. Install Node.js >= 18.19.0:"
+        log_error "Node.js not found. Install Node.js >= 20.0.0:"
         log_info "  macOS: brew install node"
         exit 1
     fi
@@ -233,7 +233,7 @@ check_prerequisites() {
     local node_version
     node_version="$(node -v)"
     if ! node_version_is_supported "$node_version"; then
-        log_error "Node.js version too old (found $node_version, need >=18.19.0)"
+        log_error "Node.js version too old (found $node_version, need >=20.0.0)"
         exit 1
     fi
     log_ok "Node.js $(node -v)"

--- a/tests/runtime/test_runtime_hooks.sh
+++ b/tests/runtime/test_runtime_hooks.sh
@@ -35,6 +35,36 @@ else printf '[hooks]\nenabled = true\n' > "$X_TOML"; fi
 if [ -f "$HOME/.gemini/config/hooks.json" ]; then cp "$HOME/.gemini/config/hooks.json" "$A_JSON"
 else printf '{"forgewright-policy":{"PreToolUse":[]}}\n' > "$A_JSON"; fi
 
+# Seed the preservation invariant explicitly instead of assuming the developer's
+# real Claude configuration already contains a GitNexus hook.
+python3 - "$C_JSON" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    data = json.load(handle)
+hooks = data.setdefault("hooks", {})
+pre_tool = hooks.get("PreToolUse")
+if not isinstance(pre_tool, list):
+    pre_tool = []
+    hooks["PreToolUse"] = pre_tool
+pre_tool.append(
+    {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": "gitnexus mcp",
+            }
+        ],
+    }
+)
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(data, handle, indent=2)
+    handle.write("\n")
+PY
+
 INST=(bash "$INSTALLER" --claude-settings "$C_JSON" --codex-config "$X_TOML" --agy-hooks "$A_JSON")
 
 # Normalise the copies to "not wired" before measuring anything. The seeds come

--- a/tests/runtime/test_runtime_p1.sh
+++ b/tests/runtime/test_runtime_p1.sh
@@ -203,8 +203,18 @@ assert_eq "$(wc -l < "$GATELOG" | tr -d ' ')" "$before" "non-Bash tool calls are
 # Latency budget (plan §G4: p95 < 100ms), measured on the reject path.
 p="$(mk_payload 'git status')"
 : > "$SANDBOX/times.txt"
+now_ns() {
+  local timestamp
+  timestamp="$(date +%s%N 2>/dev/null)"
+  case "$timestamp" in
+    ''|*[!0-9]*) python3 -c 'import time; print(time.monotonic_ns())' ;;
+    *) printf '%s\n' "$timestamp" ;;
+  esac
+}
 for _ in $(seq 1 30); do
-  t0=$(date +%s%N); printf '%s' "$p" | bash "$GATE" >/dev/null 2>&1; t1=$(date +%s%N)
+  t0="$(now_ns)"
+  printf '%s' "$p" | bash "$GATE" >/dev/null 2>&1
+  t1="$(now_ns)"
   echo $(( (t1 - t0) / 1000000 )) >> "$SANDBOX/times.txt"
 done
 p95="$(sort -n "$SANDBOX/times.txt" | awk '{a[c++]=$1} END{print a[int(c*0.95)]}')"

--- a/tests/setup/test-forgewright-mcp-setup.sh
+++ b/tests/setup/test-forgewright-mcp-setup.sh
@@ -120,6 +120,8 @@ cleanup() {
     cd "$SCRIPT_DIR"
     rm -rf "$TEST_PROJECT"
 }
+# The trap command assigns status before reading it in the same shell.
+# shellcheck disable=SC2154
 trap 'status=$?; cleanup; exit $status' EXIT HUP INT TERM
 
 # ─── Tests ─────────────────────────────────────────────────────
@@ -197,7 +199,7 @@ $output"
 const [manifestPath, lockPath] = process.argv.slice(2);
 const manifest = require(manifestPath);
 const lock = require(lockPath);
-if (manifest.engines?.node !== '>=18.19.0' ||
+if (manifest.engines?.node !== '>=20.0.0' ||
     lock.packages?.['']?.engines?.node !== manifest.engines.node) process.exit(1);
 for (const name of Object.keys(manifest.dependencies || {})) {
   const entry = lock.packages?.[`node_modules/${name}`];
@@ -1524,18 +1526,18 @@ test_round7_safety_boundaries() {
 
     if bash -c '
         source "$1"
-        node_version_is_supported v18.19.0
-        node_version_is_supported v18.19.1
-        node_version_is_supported v19.0.0
-        ! node_version_is_supported v18.18.99
-        ! node_version_is_supported v18.19
+        node_version_is_supported v20.0.0
+        node_version_is_supported v20.0.1
+        node_version_is_supported v21.0.0
+        ! node_version_is_supported v19.99.99
+        ! node_version_is_supported v20.0
     ' _ "${SCRIPT_DIR}/forgewright-mcp-setup.sh" && bash -c '
         source "$1"
-        node_version_is_supported v18.19.0
-        ! node_version_is_supported v18.18.99
+        node_version_is_supported v20.0.0
+        ! node_version_is_supported v19.99.99
         ! node_version_is_supported invalid
     ' _ "$FORGEWRIGHT_DIR/scripts/bootstrap/forgewright-setup.sh"; then
-        pass "Canonical and bootstrap Node preflights enforce exact >=18.19.0 semantics"
+        pass "Canonical and bootstrap Node preflights enforce exact >=20.0.0 semantics"
     else
         fail "Node minimum-version comparison is inconsistent"
     fi

--- a/tests/unit_tests/test_hook_schema.py
+++ b/tests/unit_tests/test_hook_schema.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 import tomllib
 from pathlib import Path
@@ -211,6 +212,70 @@ def test_codex_stop_gate_emits_one_parseable_block_json(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["decision"] == "block"
     assert "validator" in payload["reason"].lower()
+
+
+def test_codex_stop_gate_surfaces_bounded_redacted_evidence_reason(
+    tmp_path: Path,
+) -> None:
+    fake_secret = "sk-" + ("a" * 32)
+    result = run_stop_gate(
+        tmp_path,
+        "CODEX",
+        f"{VALID_VERIFY}\nDiagnostic fixture: {fake_secret}",
+        files=["src/app.ts"],
+    )
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["decision"] == "block"
+    assert payload["reason"].startswith("MISSING:")
+    assert len(payload["reason"]) <= 512
+    assert fake_secret not in payload["reason"]
+
+
+def test_codex_stop_gate_bounds_evidence_stderr_input(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    clean_git_workspace(workspace)
+
+    scripts_dir = tmp_path / "scripts" / "lite"
+    shutil.copytree(ROOT / "scripts/lite", scripts_dir)
+    fake_secret = "sk-" + ("z" * 32)
+    (scripts_dir / "verify-gate.sh").write_text(
+        """#!/usr/bin/env bash
+python3 - "$1" <<'PYEOF'
+import json
+import sys
+
+sys.stderr.write("x" * 65536)
+sys.stderr.write("\\nMISSING: hidden diagnostic " + "sk-" + ("z" * 32))
+print(json.dumps({"decision": "block", "reason": "fixture"}))
+PYEOF
+""",
+        encoding="utf-8",
+    )
+
+    payload = json.dumps({"response_content": VALID_VERIFY, "files": ["src/app.ts"]})
+    env = clean_git_environment()
+    env["FORGEWRIGHT_RULE_LEDGER"] = str(workspace / "rule-ledger.jsonl")
+    result = subprocess.run(
+        ["bash", str(scripts_dir / "stop-gate.sh"), "--platform", "CODEX"],
+        cwd=workspace,
+        env=env,
+        input=payload,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    parsed = json.loads(result.stdout)
+    assert parsed["decision"] == "block"
+    assert parsed["reason"] == (
+        "Forgewright evidence validator rejected the response payload."
+    )
+    assert len(parsed["reason"]) <= 512
+    assert fake_secret not in parsed["reason"]
 
 
 def test_codex_stop_gate_rejects_oversized_payload_with_parseable_json(

--- a/tests/unit_tests/test_routing_control_plane.py
+++ b/tests/unit_tests/test_routing_control_plane.py
@@ -19,7 +19,12 @@ ATTESTATION_KEY = b"test-only-routing-attestation-key-32-bytes"
 
 
 def evaluate_control_plane(evidence: dict) -> dict:
-    evidence["attestation_hmac_sha256"] = sign_evidence(evidence, ATTESTATION_KEY)
+    try:
+        evidence["attestation_hmac_sha256"] = sign_evidence(evidence, ATTESTATION_KEY)
+    except (TypeError, ValueError):
+        # Exercise field validation for payloads that canonical JSON correctly
+        # refuses to attest (for example, non-finite numeric evidence).
+        pass
     return _evaluate_control_plane(evidence, ATTESTATION_KEY)
 
 


### PR DESCRIPTION
## Summary

- pin the MCP SDK and vulnerable transitive packages to reproducible, production-audit-clean versions
- require Node.js 20+ for the MCP runtime because the secure `@hono/node-server` 2.x line requires Node 20; the standalone CLI remains Node 18 compatible
- bound stop-gate diagnostic reads to 64 KiB, redact verifier failures into an allowlisted reason, cap the reason length, and preserve parseable Codex hook JSON
- make runtime-hook evidence self-contained and add regression coverage for oversized/secret-bearing diagnostics, Node-version boundaries, macOS timing portability, and invalid routing evidence

## Security and compatibility

- root and MCP production audits report 0 vulnerabilities
- the latest compatible Hono 1.x probe still reports GHSA-frvp-7c67-39w9, so retaining Node 18 for MCP would not provide an audit-clean dependency path
- no credentials or raw verifier stderr are stored in fixtures, logs, or hook output

## Validation

- clean root and MCP installs
- clean-install verifier: install, build, CLI typecheck/build, and golden path PASS
- MCP Vitest: 165 passed
- Python 3.12 unit suite: 326 passed
- runtime hooks: 55 passed
- runtime P0/P1/P2: 39 / 32 / 27 passed
- setup matrix: 78 passed, 0 failed, 0 skipped
- launcher, product-truth, golden-path, Ruff, ShellCheck, lint, format, and production audits PASS
- independent security/reproducibility review: GO, no P0-P3 findings
- GitNexus staged impact: LOW, 15 files, 35 changed symbols, 0 affected execution flows
